### PR TITLE
Patch .gitignore to work with nested crates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+target
 **/*.rs.bk


### PR DESCRIPTION
With the new repo organization scheme, nested crates aren't handled correctly by `.gitignore` -- specifically, their `target` directories are all included, since the default `.gitignore` for Rust crates only ignores the `target` directory present in `root`. This means that Git tries to add thousands of files present in nested `target` directories to a commit.

This change simply makes it so that any directory named `target` is ignored. This is the [same solution](https://github.com/CraneStation/wasmtime/blob/ecc981687091f28d4770503e4b704b8abb868c93/.gitignore#L6) the Wasmtime project uses.