### PR TITLE
wasmtime-basic: fix README and build.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Programs for demonstrating the Enarx subcomponents and eventually their synergy.
 A demonstration of running encrypted code in an SEV VM.
 
 ## Wasmtime Basic
-Compiling Rust/C/C++ programs to WASI-compliant WASM and running it natively using a Rust-powered JIT.
+Compiling either a C or Rust program to WASM and running it natively using a Rust-powered JIT.

--- a/wasmtime-basic/README.md
+++ b/wasmtime-basic/README.md
@@ -1,6 +1,6 @@
 # Wasmtime Basic Demo
 
-This is an example crate demonstrating how Enarx may use Wasmtime, a Rust-powered JIT, to natively run programs from several different source languages (Rust/C/C++) compiled to WASI-compliant WASM.
+This is an example crate demonstrating how Enarx may use Wasmtime, a Rust-powered JIT, to natively run programs from several different source languages (Rust/C/C++) compiled to WASM.
 
 ## Running the demo
 

--- a/wasmtime-basic/build.rs
+++ b/wasmtime-basic/build.rs
@@ -22,16 +22,18 @@ fn main() {
 
     if cfg!(feature = "rust") {
         println!("Compiling Rust source to WASM...");
-        Command::new("rustc")
+        assert!(Command::new("rustc")
             .arg("-C")
             .arg("lto")
+            .arg("-C")
             .arg("opt-level=3")
             .arg("--target")
             .arg("wasm32-unknown-unknown")
             .arg("-o")
             .arg(format!("{}/add.wasm", out))
             .arg("src/add.rs")
-            .spawn()
-            .expect("failed to compile WASM module");
+            .status()
+            .expect("failed to compile WASM module")
+            .success());
     }
 }


### PR DESCRIPTION
* The README mentions compiling to WASI compliant WASM but the demo
doesn't use WASI
* The `rustc` command misses an argument and fails, which went unnoticed
because of a missing assert on its status.

Fixes #12.