### PR TITLE
Implement basic Rust testing with GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,17 @@
+name: Rust-Tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+    - name: rustfmt
+      run: cargo fmt -- --check


### PR DESCRIPTION
As documented in #11, we've wanted to add basic CI to the demo repo (and all Enarx repos) via GitHub Actions. This PR implements a basic implementation of standard Rust tests.

Resolves: #11 