### PR TITLE
wasmtime-basic: print i32 value instead of vec

### DIFF
--- a/wasmtime-basic/src/main.rs
+++ b/wasmtime-basic/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
     let result = wasm_add_full();
     println!("Finished. Results:");
     match result.unwrap() {
-        ActionOutcome::Returned { values } => println!("Output: {:#?}", values),
+        ActionOutcome::Returned { values } => println!("Output: {:#}", values[0]),
         ActionOutcome::Trapped { message } => println!("Trap from within function: {}", message),
     }
     println!("Done.");


### PR DESCRIPTION
This commit is just a suggestion to change the output from the
current vector to just the i32 value. For example, currently the
following is displayed:
```console
Finished. Results:
Output: [
    I32(
        12,
    ),
]
Done.
```
With the changes in this commit this output would be:
```console
Finished. Results:
Output: 12: i32
Done.
```