### PR TITLE
Fix the link to the demo videos for AMD SEV

### DIFF
--- a/amd-sev/README.md
+++ b/amd-sev/README.md
@@ -1,5 +1,5 @@
 # AMD SEV Demonstration
 
-Check out the [AMD SEV demo](https://github.com/enarx/enarx/wiki/Demo-Video)
+Check out the [AMD SEV demo](https://github.com/enarx/enarx/wiki/Demo-Videos)
 to see it in action. Instructions are included on the linked wiki page if
 you'd like to run it yourself!


### PR DESCRIPTION
There should be an 's' on the end of that link :-)